### PR TITLE
StackClash_x86 change bytes for bytearray, interpretation wrong for python 2.6-7

### DIFF
--- a/StackClash_x86.py
+++ b/StackClash_x86.py
@@ -27,7 +27,7 @@ system_chunks = []
 cmd_chunks = []
 
 def makeHeader(num):
-    return bytes("POST /jsproxy HTTP/1.1\r\nContent-Length: ") + bytes(str(num)) + bytes("\r\n\r\n")
+    return bytearray("POST /jsproxy HTTP/1.1\r\nContent-Length: ") + bytearray(str(num)) + bytearray("\r\n\r\n")
 
 def makeSocket(ip, port):
     s = socket.socket()


### PR DESCRIPTION
The new bytes type is 3.x only. The 2.x bytes built-in is just an alias to the str type. There is no new type called bytes in 2.x; Just a new alias and literal syntax for str.

https://github.com/ebranca/owasp-pysec/wiki/Bytes-type-in-python-2-and-python-3